### PR TITLE
node12 subst for node8 since lambda forbids 8

### DIFF
--- a/aws_cloudformation/templates/add-nic-attachment-service.template
+++ b/aws_cloudformation/templates/add-nic-attachment-service.template
@@ -121,7 +121,7 @@
                         ]
                     ]
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs12.x",
                 "Role": {
                     "Fn::GetAtt": [
                         "IamRoleNicAttachment",
@@ -192,7 +192,7 @@
                         ]
                     ]
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs12.x",
                 "Role": {
                     "Fn::GetAtt": [
                         "IamRoleNicAttachment",

--- a/aws_cloudformation/templates/create-autoscale-handler.template
+++ b/aws_cloudformation/templates/create-autoscale-handler.template
@@ -486,7 +486,7 @@
                         ]
                     ]
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs12.x",
                 "Role": {
                     "Fn::GetAtt": [
                         "FgtAsgHandlerIamRole",
@@ -648,7 +648,7 @@
                         ]
                     ]
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs12.x",
                 "Role": {
                     "Fn::GetAtt": [
                         "FgtAsgHandlerIamRole",

--- a/aws_cloudformation/templates/create-fortianalyzer.template
+++ b/aws_cloudformation/templates/create-fortianalyzer.template
@@ -404,7 +404,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs12.x",
                 "Timeout": 300,
                 "Environment": {
                     "Variables": {

--- a/aws_cloudformation/templates/create-tgw-vpn-handler.template
+++ b/aws_cloudformation/templates/create-tgw-vpn-handler.template
@@ -97,7 +97,7 @@
                         ]
                     ]
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs12.x",
                 "Role": {
                     "Fn::GetAtt": [
                         "IamRoleTransitGatewayVpnHandler",


### PR DESCRIPTION
AWS Lambda forbids using runtime nodejs8.10, so let's use runtime nodejs12.x instead